### PR TITLE
bower integration fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "canvasResize",
-  "main": "canvasResize.js",
+  "main": "src/canvasResize.js",
   "version": "1.2.7",
   "homepage": "https://github.com/robertdmunn/canvasResize",
   "authors": [


### PR DESCRIPTION
Bower main property has to point on the right js main file to compile with frontend builders like brunch.
This error could cause a lot of headache for people who wants to compile and use the library with brunch which use the component main property to build.

At the moment, this do not cause any visible error when compiling even with debug mode enabled.

(Nice work by the way).
